### PR TITLE
Fix: Using `Acadamic Year` instead of `Year of Oral Defense` and some feedback

### DIFF
--- a/ntut-labels.tex
+++ b/ntut-labels.tex
@@ -41,6 +41,10 @@
 % Month of Oral Defense（Chinese）
 \newcommand\cMonth{七} 
 
+% 畢業學年度 (中文)
+% 如 112 學年度第2學期畢業，當時為民國113年6月，學年度即為112，不是113。
+\newcommand\cAcademicYear{一百一十二}
+
 % 畢業學期（中文）
 % Academic Year (Chinese)
 \newcommand\cGraduateSemester{二}
@@ -72,6 +76,8 @@
 % Department Name（English）
 \newcommand\fulldeptEname{Department of Computer Science and Information Engineering}
 
+\newcommand\deptEname{Computer Science and Information Engineering}
+
 % 學位名 (英文)
 % Degree（English）
 \newcommand\degreeEname{Master of Science}
@@ -79,6 +85,10 @@
 % 口試年份 (阿拉伯數字、西元)
 % Year of Oral Defense（English）
 \newcommand\eYear{2023}
+
+% 口試月份 (英文)
+% Month of Oral Defense（English）
+\newcommand\eMonth{June}
 
 %畢業級別；用於書背列印；若無此需要可忽略
 \newcommand\GraduationClass{111}

--- a/page/abstract.tex
+++ b/page/abstract.tex
@@ -4,14 +4,14 @@
         % 論文名稱，請在 ntut-labels.tex 定義
         \noindent \text 論文名稱：\cTitle
 
-        % 論文頁碼，請在 ntut-labels.tex 定義
-        \noindent \text 頁碼：（請自己填）
+        % 論文頁數，請自己填
+        \noindent \text 頁數：（請自己填）頁
 
         % 校所別，請在 ntut-labels.tex 定義
         \noindent \text 校所別：\univCname \space \deptCname
 
         % 畢業時間，請在 ntut-labels.tex 定義
-        \noindent \text 畢業時間：\cYear 學年度 \space 第\cGraduateSemester 學期
+        \noindent \text 畢業時間：\cAcademicYear 學年度 \space 第\cGraduateSemester 學期
 
         % 學位，請在 ntut-labels.tex 定義
         \noindent \text 學位：\degreeCname


### PR DESCRIPTION
Hello! 我做了一些重要的修正，麻煩 review 謝謝!

1. 中文畢業時間應該使用 "學年度" 而不是 "畢業年份"，例如今年 113 年畢業學生的畢業時間應該是 112-2
2. `\deptEname` 似乎在[上個 commit](https://github.com/ntut-xuan/NTUT-Thesis-Template/commit/aa2292f4c1b108f44417419164060e477dffa85a#diff-7924c21aaecd36eac8e51667d698afe3772791be1829a01297ef8de08d912a51L59) 被誤刪，導致編譯錯誤
3. abstract 的 `頁碼` 應該換成 `頁數`

以上是比較 critical 的問題，下面另外有幾個小建議給你參考看看：
1. `ZhAbstract` 的 `摘要` 可以在中間加全形空格或`hspace`，例如: `摘　要`，以符合學校的格式規定
![image](https://github.com/ntut-xuan/NTUT-Thesis-Template/assets/39915562/21899d29-9e46-428d-abeb-e1e737992eef)

2. `EnAbstract` 的  `Abstract` 可以全改成全大寫，例如 `ABSTRACT`，以符合學校格式規定
![image](https://github.com/ntut-xuan/NTUT-Thesis-Template/assets/39915562/0c8c85d1-1b4d-4653-b7ad-c9e2ce73773f)

3. Chapter 與 Page Top 若按照學校格式規定的話是需要有一個 `12pt; 1.5 倍行高` 的換行的
![image](https://github.com/ntut-xuan/NTUT-Thesis-Template/assets/39915562/8b8b9b39-80a6-41be-af7e-5e6cb7ddaf1d)

4. `\usepackage[backend=bibtex]{biblatex}` 的 `backend=bibtex` 或許可以改成較現代的 `backend=biber` 

5. 目錄可能需加上 "圖目錄" 和 "表目錄" ，並且注意他們的頁碼與 hyperref 是否正確

6. 粗體斜體的設置可以改成 `\xeCJKsetup{AutoFakeBold=2.5, AutoFakeSlant=true}` 才會跟學校 word 出來的粗度一樣

7. (這個不知道是否只有我有問題) ，字體若使用"標楷體"，輸出的 pdf 在 100% 縮放時字會忽粗忽細的，若改成 `TW-Kai` ([中文全字庫](https://data.gov.tw/dataset/5961)，我國行政院提供) 則不會有這個問題。
    
    使用 標楷體 (DF-Kai) 輸出的 pdf (以 100% 縮放檢視):
    ![image](https://github.com/ntut-xuan/NTUT-Thesis-Template/assets/39915562/5258b814-fe7f-4d2b-b553-dd25b906fa12)
    
    使用 中文全字庫 (TW-Kai) 輸出的 pdf (以 100% 縮放檢視):
    ![image](https://github.com/ntut-xuan/NTUT-Thesis-Template/assets/39915562/ead2f499-7f58-4400-a311-88763120bad9)

8. 中文論文引用可以參考以下:
    ```latex
    % main.tex
    \DeclareDelimFormat{customnewblock}{，\space}
    \DeclareBibliographyDriver{chthesis}{%
        \printnames{author}%
        \customnewblock
        \printfield{title}%
        \customnewblock
        \printfield{type}%
        \customnewblock
        \printfield{howpublished}%
        \customnewblock
        \printfield{year}%
        。
    }
    \DeclareFieldFormat
      [chthesis]
      {title}{\textbf{#1}}

    % reference.bib
    @chthesis{local_clusterfuzz:lin,
      author  = {林辰臻},
      howpublished  = {國立臺灣大學資訊工程學系},
      title   = {透過逆向工程解耦開源軟體中的雲端服務相依性：以 ClusterFuzz 為例},
      year    = {2023},
      type    = {碩士論文},
    }
    ```
    
    ![image](https://github.com/ntut-xuan/NTUT-Thesis-Template/assets/39915562/adc8a708-2e97-45ab-ba8f-3bc938c62e43)
