### PR TITLE
Fix: Adjust right page margin

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -19,7 +19,7 @@
 \xeCJKsetup{AutoFakeBold=true, AutoFakeSlant=true}
 \setCJKmainfont{標楷體} % 中文字體
 \setmainfont{Times New Roman} % 英文字體
-\geometry{a4paper,total={297mm,210mm},top=4.5cm,bottom=0.75cm,left=2.5cm,right=2.2cm} % 頁面設定，不需修改
+\geometry{a4paper,total={297mm,210mm},top=4.5cm,bottom=0.75cm,left=2.5cm,right=2.5cm} % 頁面設定，不需修改
 \pagestyle{plain} % 頁碼
 \addbibresource{reference.bib}
 


### PR DESCRIPTION
Hi 

我發現 \geometry 參數中的 right 跟 left 不同，導致標題或是內文不是真的置中，左邊會長一些。
![144258](https://github.com/user-attachments/assets/62bbfb30-c62f-458f-b533-566b4bd9d486)
![144308](https://github.com/user-attachments/assets/7c6753d0-3201-4742-a328-ef87de3f19a6)

參考學校 word 的設定，將 right 參數從 2.2cm 改為 2.5cm，讓左右一致。
![image](https://github.com/user-attachments/assets/0d663e1b-6f15-42b4-ae7b-18555708a4bf)


