### PR TITLE
Fix incorrect TOC page number and add table/figure list entries

### DIFF
--- a/ntut-report.cls
+++ b/ntut-report.cls
@@ -731,9 +731,9 @@
     \chapter*{\contentsname
         \@mkboth{%
            \MakeUppercase\contentsname}{\MakeUppercase\contentsname}}%
+    \addcontentsline{toc}{chapter}{目錄}
     \@starttoc{toc}%
     \if@restonecol\twocolumn\fi
-    \addcontentsline{toc}{chapter}{目錄}
     }
 \newcommand*\l@part[2]{%
   \ifnum \c@tocdepth >-2\relax
@@ -780,6 +780,7 @@
       \@restonecolfalse
     \fi
     \chapter*{\listfigurename}%
+    \addcontentsline{toc}{chapter}{圖目錄}%
       \@mkboth{\MakeUppercase\listfigurename}%
               {\MakeUppercase\listfigurename}%
     \@starttoc{lof}%
@@ -793,6 +794,7 @@
       \@restonecolfalse
     \fi
     \chapter*{\listtablename}%
+    \addcontentsline{toc}{chapter}{表目錄}%
       \@mkboth{%
           \MakeUppercase\listtablename}%
          {\MakeUppercase\listtablename}%


### PR DESCRIPTION
1. 修正目錄頁中，「目錄」頁碼錯誤
2. 於目錄頁補上「表目錄」、「圖目錄」對應頁碼
<img width="554" height="253" alt="fixtoc" src="https://github.com/user-attachments/assets/5f13e85d-9513-466b-a370-bed8149510c8" />

Resolve: #4 