### PR TITLE
Fix: Remove duplicate inclusion of titlepage.tex, switch to \input

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -36,7 +36,7 @@
 \CenterWallPaper{.64}{ntut-logo.png}
 
 % 封面、要浮水印 Cover with a watermark
-\include{page/titlepage.tex}
+\input{page/titlepage.tex}
 % 「學位論文口試委員會審定書」掃描檔，請檢附完整簽名之審定書掃描檔
 % Please add "Oral Defense Committee Signature Form" with complete signatures.
 \includepdf[pages=-]{static-page/signpage.pdf}


### PR DESCRIPTION
### Summary
Consecutive `\include` of the same `.tex` file (`titlepage.tex`) may lead to compilation errors due to how LaTeX handles `\include` and auxiliary files.  
This PR replaces the duplicate `\include` calls with `\input`, which avoids these issues.

### Changes
- Replaced `\include{page/titlepage.tex}` with `\input{page/titlepage}`.  
- Applied the same change to `blankpage`.  
- No visual output changes; this is purely a code optimization to ensure stable compilation.

### Rationale
- `\include` is not designed for inserting the same file consecutively.  
- `\input` simply pastes the file inline, making it more suitable for front matter like title pages and blank pages.